### PR TITLE
[codex] Fix glass button hover contrast

### DIFF
--- a/docs/src/components/desktop/apps/DeveloperApp/previews.tsx
+++ b/docs/src/components/desktop/apps/DeveloperApp/previews.tsx
@@ -2037,9 +2037,9 @@ function BadgeGlassExample() {
 function ButtonGlassExample() {
   return (
     <div className="flex flex-wrap gap-3">
-      <Button type="button" variant="primary" className="backdrop-blur-sm">Glass Button</Button>
-      <Button type="button" variant="secondary" className="backdrop-blur-sm">Secondary Glass</Button>
-      <Button type="button" variant="outline" className={glassStyles}>Outline Glass</Button>
+      <Button type="button" variant="primary" glass>Glass Button</Button>
+      <Button type="button" variant="secondary" glass>Secondary Glass</Button>
+      <Button type="button" variant="outline" glass>Outline Glass</Button>
     </div>
   );
 }

--- a/docs/src/components/desktop/apps/DeveloperApp/previews.tsx
+++ b/docs/src/components/desktop/apps/DeveloperApp/previews.tsx
@@ -2009,7 +2009,7 @@ function ImageClickToEnlargeExample() {
 }
 
 // Glass Example Components - These show glassmorphism styling concepts
-// Note: Glass styling is achieved via className, not a glass prop
+// Note: Buttons use the glass prop; other previews reuse shared glass utility classes.
 const glassStyles = "bg-white/10 dark:bg-white/5 backdrop-blur-xl border border-white/20 dark:border-white/10";
 
 function CardGlassExample() {

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -80,6 +80,20 @@ const variantClasses: Record<ButtonVariant, string> = {
 	accent: "bg-violet-500 text-white hover:bg-violet-600",
 };
 
+const glassHoverClasses: Record<ButtonVariant, string> = {
+	default: "hover:bg-white/80 dark:hover:bg-zinc-900/80 hover:backdrop-blur-md",
+	primary: "hover:bg-blue-600/90 hover:backdrop-blur-md",
+	secondary: "hover:bg-white/80 dark:hover:bg-zinc-900/80 hover:backdrop-blur-md",
+	success: "hover:bg-emerald-600/90 hover:backdrop-blur-md",
+	warning: "hover:bg-amber-600/90 hover:backdrop-blur-md",
+	info: "hover:bg-sky-600/90 hover:backdrop-blur-md",
+	destructive: "hover:bg-red-600/90 hover:backdrop-blur-md",
+	outline: "hover:bg-white/80 dark:hover:bg-zinc-900/80 hover:backdrop-blur-md",
+	ghost: "hover:bg-white/80 dark:hover:bg-zinc-900/80 hover:backdrop-blur-md",
+	link: "hover:backdrop-blur-md",
+	accent: "hover:bg-violet-600/90 hover:backdrop-blur-md",
+};
+
 const sizeClasses: Record<ButtonSize, string> = {
 	default: "h-9 px-4 py-2",
 	sm: "h-8 rounded-lg px-3 text-xs",
@@ -149,7 +163,7 @@ const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonProps>(
 					variantClasses[variant],
 					sizeClasses[effectiveSize],
 					fullWidth && "w-full",
-					glass && "hover:bg-white/80 dark:hover:bg-zinc-900/80 hover:backdrop-blur-md",
+					glass && glassHoverClasses[variant],
 					className,
 				)}
 				// biome-ignore lint/suspicious/noExplicitAny: Framer Motion onDrag conflicts with HTML onDrag


### PR DESCRIPTION
## Summary
- preserve readable hover contrast for `glass` buttons by variant
- update the docs glass-button preview to exercise the actual `glass` prop

## Root cause
`Button` appended one generic glass hover class for every variant:

```ts
hover:bg-white/80 dark:hover:bg-zinc-900/80
```

That class overrides filled variants such as `primary`. In light mode, `variant="primary" glass` becomes a near-white hover surface while the text remains `text-white`, making the label effectively disappear.

## Changes
- add `glassHoverClasses` keyed by `ButtonVariant`
- keep filled variants on readable variant-colored hover surfaces
- keep neutral variants on frosted neutral hover surfaces
- update the docs preview to use `glass` directly instead of ad hoc backdrop classes

## Validation
- `npm run build`
- `cd docs && npm run build`
- verified the docs Button > Glass example in light mode; the primary glass button no longer flips to a white hover surface


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved glass button behavior so hover and backdrop-blur styles are variant-aware, ensuring consistent visual effects across all button types.
* **Documentation**
  * Updated the example preview and accompanying comment to use the glass prop and clarify how glass styling is applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/surajmandalcell/darwin-ui/pull/2)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->